### PR TITLE
Update step-cli version to 0.29.0

### DIFF
--- a/step-ca-client/Dockerfile
+++ b/step-ca-client/Dockerfile
@@ -7,7 +7,7 @@ COPY rootfs /
 
 # Setup base
 RUN apk add --no-cache \
-    step-cli=0.28.5-r0
+    step-cli=0.29.0-r0
 
 # Build arguments
 ARG BUILD_ARCH


### PR DESCRIPTION
# Proposed Changes
This patch bumps the step-cli package version from the previous release to 0.29.0
https://security.alpinelinux.org/srcpkg/step-cli