### PR TITLE
Adds network to apparmor.txt

### DIFF
--- a/step-ca-client/apparmor.txt
+++ b/step-ca-client/apparmor.txt
@@ -7,6 +7,8 @@ profile step-ca-client flags=(attach_disconnected,mediate_deleted) {
   file,
   signal (send) set=(kill,term,int,hup,cont),
 
+  network,
+
   # S6-Overlay
   /init ix,
   /bin/** ix,
@@ -32,6 +34,8 @@ profile step-ca-client flags=(attach_disconnected,mediate_deleted) {
 
   profile step flags=(attach_disconnected,mediate_deleted) {
     #include <abstractions/base>
+
+    network,
 
     # Receive signals from S6-Overlay
     signal (receive) peer=*_step-ca-client,


### PR DESCRIPTION
# Proposed Changes

Adds network access to apparmor. Without this my container (running in a supervised install) doesn´t get access to network and fails. I am not sure if changes are also needed in your hassio-repositories, these changes worked in my locally installed clone of this repo.
